### PR TITLE
feat: implemented send, accept, and decline join requests

### DIFF
--- a/backend/routes/events.js
+++ b/backend/routes/events.js
@@ -1,6 +1,6 @@
 const express=require('express');
 const router=express.Router();
-const {createEvent, getEvents}=require('../controllers/eventController');
+const {createEvent, getEvents, sendJoinRequests, manageJoinRequest}=require('../controllers/eventController');
 const auth=require('../middleware/authMiddleware');
 
 // @route   POST /api/events
@@ -13,5 +13,15 @@ router.post('/', auth, createEvent);
 // @access  Public
 router.get('/', getEvents);
 
+
+// @route   POST /api/events/:id/requests
+// @desc    Send a join request to an event
+// @access  Private
+router.post('/:id/requests', auth, sendJoinRequests);
+
+// @route   PUT /api/events/:id/requests/:userId
+// @desc    Accept or decline a join request
+// @access  Private (Host Only)
+router.put('/:id/requests/:userId', auth, manageJoinRequest);
 
 module.exports=router;


### PR DESCRIPTION
This pull request adds new API endpoints to allow users to send join requests to an event and for the event host to manage those requests. This feature adds a layer of privacy and control for event creators.

Key Changes:

POST /api/events/:id/requests: Adds a new endpoint for users to send a join request.

PUT /api/events/:id/requests/:userId: Adds a new endpoint for the event host to accept or decline a pending join request.

Implemented host-only access control to ensure only the event creator can manage requests.

Added logic to prevent duplicate requests or a host from joining their own event.